### PR TITLE
Fix missing semicolon in io file

### DIFF
--- a/apps_script/io.gs
+++ b/apps_script/io.gs
@@ -1,33 +1,33 @@
 // Project folder and raw staging removed for simplified standalone script
 
 function getOrCreateGamesSpreadsheet() {
-  const props = getScriptProps();
-  const existingId = props.getProperty('SPREADSHEET_ID_GAMES');
+  var props = getScriptProps();
+  var existingId = props.getProperty('SPREADSHEET_ID_GAMES');
   if (existingId) {
     try {
       return SpreadsheetApp.openById(existingId);
     } catch (e) {}
   }
-  const ss = SpreadsheetApp.create(getSpreadsheetNameGames());
+  var ss = SpreadsheetApp.create(getSpreadsheetNameGames());
   props.setProperty('SPREADSHEET_ID_GAMES', ss.getId());
   return ss;
 }
 
 function getOrCreateMetricsSpreadsheet() {
-  const props = getScriptProps();
-  const existingId = props.getProperty('SPREADSHEET_ID_METRICS');
+  var props = getScriptProps();
+  var existingId = props.getProperty('SPREADSHEET_ID_METRICS');
   if (existingId) {
     try {
       return SpreadsheetApp.openById(existingId);
     } catch (e) {}
   }
-  const ss = SpreadsheetApp.create(getSpreadsheetNameMetrics());
+  var ss = SpreadsheetApp.create(getSpreadsheetNameMetrics());
   props.setProperty('SPREADSHEET_ID_METRICS', ss.getId());
   return ss;
 }
 
 function getOrCreateSheet(ss, sheetName, headers) {
-  let sheet = ss.getSheetByName(sheetName);
+  var sheet = ss.getSheetByName(sheetName);
   if (!sheet) {
     sheet = ss.insertSheet(sheetName);
   }
@@ -42,12 +42,12 @@ function getOrCreateSheet(ss, sheetName, headers) {
 
 function writeRowsChunked(sheet, rows, startRow) {
   if (!rows || rows.length === 0) return;
-  const maxChunk = 5000;
-  let offset = 0;
-  const colCount = rows[0].length;
-  const start = startRow || sheet.getLastRow() + 1;
+  var maxChunk = 5000;
+  var offset = 0;
+  var colCount = rows[0].length;
+  var start = startRow || sheet.getLastRow() + 1;
   while (offset < rows.length) {
-    const chunk = rows.slice(offset, offset + maxChunk);
+    var chunk = rows.slice(offset, offset + maxChunk);
     sheet.getRange(start + offset, 1, chunk.length, colCount).setValues(chunk);
     offset += chunk.length;
   }


### PR DESCRIPTION
Replace `let`/`const` with `var` in `apps_script/io.gs` to resolve a syntax error in legacy JavaScript environments.

The "Missing ; before statement" error was caused by the use of ES6 `let`/`const` declarations in an environment (likely Google Apps Script's legacy Rhino runtime) that does not support them. This change ensures compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c00b3c4-aba0-49d2-980e-664f8f777645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c00b3c4-aba0-49d2-980e-664f8f777645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

