### PR TITLE
Fix undefined getOrCreateRawFolder function

### DIFF
--- a/apps_script/backfill.gs
+++ b/apps_script/backfill.gs
@@ -99,7 +99,6 @@ function fullBackfill() {
     var metricsSS2 = getOrCreateMetricsSpreadsheet();
     var username = getConfiguredUsername();
     var archivesSheet = getOrCreateSheet(metricsSS2, CONFIG.SHEET_NAMES.Archives, CONFIG.HEADERS.Archives);
-    var rawFolder = getOrCreateRawFolder();
     var lastRow = archivesSheet.getLastRow();
     if (lastRow < 2) return;
     var data = archivesSheet.getRange(2, 1, lastRow - 1, CONFIG.HEADERS.Archives.length).getValues();


### PR DESCRIPTION
Remove the call to `getOrCreateRawFolder()` because the function is undefined after raw staging was removed, resolving a `ReferenceError`.

The `ReferenceError` occurred because `getOrCreateRawFolder()` was called in `backfill.gs` but its definition was removed as part of the raw staging removal in `io.gs`. Removing the call resolves the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-59b6a7a0-cfb7-4694-bab9-cbd248c41db2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-59b6a7a0-cfb7-4694-bab9-cbd248c41db2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

