### PR TITLE
Investigate game backfill failure

### DIFF
--- a/apps_script/main.gs
+++ b/apps_script/main.gs
@@ -19,16 +19,14 @@ function setupProject() {
   return JSON.stringify({ gamesUrl: gamesSS.getUrl(), metricsUrl: metricsSS.getUrl() });
 }
 
-// Backfill implemented in backfill.gs
+// Orchestrator implementations live in their respective files:
+// - ingestActiveMonth: incremental.gs
+// - rebuildDailyTotals: daily.gs
+// - runCallbacksBatch: callbacks.gs
+// - fullBackfill: backfill.gs
+// - backfillLastRatings: incremental.gs
+// - recheckInactiveArchives: rollover.gs
 
-// Orchestrators exposed for triggers/cron
-function ingestActiveMonth() { /* implemented in incremental.gs */ }
-function rebuildDailyTotals() { /* implemented in daily.gs */ }
-function runCallbacksBatch() { /* implemented in callbacks.gs */ }
-function fullBackfill() { /* implemented in backfill.gs */ }
-function backfillLastRatings() { /* implemented in incremental.gs */ }
-function recheckInactiveArchives() { /* implemented in rollover.gs */ }
-
-// Enrichment jobs (stubs) — external per-game processors
-function runOpeningAnalysisBatch() { /* implemented in enrichment_openings.gs */ }
-function runGameDataBatch() { /* implemented in enrichment_gamedata.gs */ }
+// Enrichment jobs implementations:
+// - runOpeningAnalysisBatch: enrichment_openings.gs
+// - runGameDataBatch: enrichment_gamedata.gs


### PR DESCRIPTION
Remove no-op stub functions from `main.gs` to allow real orchestrator logic to execute.

The stub definitions in `main.gs` were shadowing the actual implementations of functions like `fullBackfill` and `ingestActiveMonth` located in other `.gs` files, preventing them from running. This fix ensures the real logic is executed.

---
<a href="https://cursor.com/background-agent?bcId=bc-78173d98-9107-4a8c-a056-3aef45db5e6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78173d98-9107-4a8c-a056-3aef45db5e6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

