### PR TITLE
Fix game rating backfill timestamp logic

### DIFF
--- a/apps_script/io.gs
+++ b/apps_script/io.gs
@@ -33,6 +33,17 @@ function getOrCreateMetricsSpreadsheet() {
 }
 
 function getOrCreateSheet(ss, sheetName, headers) {
+  // Guard against undefined spreadsheet handles from callers
+  if (!ss || typeof ss.getSheetByName !== 'function') {
+    try {
+      ss = SpreadsheetApp.getActive();
+    } catch (e) {}
+    if (!ss) {
+      var metricsNames = CONFIG && CONFIG.SHEET_NAMES ? CONFIG.SHEET_NAMES : {};
+      var isMetricsSheet = (sheetName === metricsNames.Archives || sheetName === metricsNames.DailyTotals || sheetName === metricsNames.DailyActive || sheetName === metricsNames.DailyArchive || sheetName === metricsNames.CallbackStats || sheetName === metricsNames.Logs);
+      ss = isMetricsSheet ? getOrCreateMetricsSpreadsheet() : getOrCreateGamesSpreadsheet();
+    }
+  }
   var sheet = ss.getSheetByName(sheetName);
   if (!sheet) {
     sheet = ss.insertSheet(sheetName);


### PR DESCRIPTION
Harden spreadsheet handling, fix exact rating application, and recompute `last_rating` based on timestamp-ordered games within each format to resolve `getSheetByName` errors and ensure accurate historical ratings.

The `TypeError: Cannot read properties of undefined (reading 'getSheetByName')` occurred because `ss` was sometimes undefined when `getOrCreateSheet` was called. Additionally, the previous `last_rating` calculation was row-based, leading to inaccuracies when games were not strictly ordered by time, which is now corrected by sorting games by `end_time` within each format before calculating historical ratings.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c711844-acb7-4edf-9926-b47ef9cbdad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c711844-acb7-4edf-9926-b47ef9cbdad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

