### PR TITLE
Debug daily script charcodeat error

### DIFF
--- a/apps_script/config.gs
+++ b/apps_script/config.gs
@@ -46,13 +46,13 @@ const CONFIG = {
       'last_rating', 'rating_change_last', 'exact_pregame_rating'
     ],
     DailyTotals: [
-      'date', 'format', 'wins', 'losses', 'draws', 'score', 'rating_start', 'rating_end', 'rating_change', 'games', 'duration_seconds', 'rating_change_exact', 'is_rating_exact'
+      'date', 'format', 'wins', 'losses', 'draws', 'score', 'rating_start', 'rating_end', 'rating_change', 'games', 'duration_seconds'
     ],
     DailyActive: [
-      'date', 'format', 'wins', 'losses', 'draws', 'score', 'rating_start', 'rating_end', 'rating_change', 'games', 'duration_seconds', 'rating_change_exact', 'is_rating_exact'
+      'date', 'format', 'wins', 'losses', 'draws', 'score', 'rating_start', 'rating_end', 'rating_change', 'games', 'duration_seconds'
     ],
     DailyArchive: [
-      'date', 'format', 'wins', 'losses', 'draws', 'score', 'rating_start', 'rating_end', 'rating_change', 'games', 'duration_seconds', 'rating_change_exact', 'is_rating_exact'
+      'date', 'format', 'wins', 'losses', 'draws', 'score', 'rating_start', 'rating_end', 'rating_change', 'games', 'duration_seconds'
     ],
     CallbackStats: [
       'url', 'type', 'id',

--- a/apps_script/daily.gs
+++ b/apps_script/daily.gs
@@ -68,7 +68,7 @@ function recomputeDailyForDates(dates) {
     var dateKey = Utilities.formatDate(d, getProjectTimeZone(), 'yyyy-MM-dd');
     if (!set[dateKey]) continue;
     var key = dateKey + '|' + format;
-    if (!buckets[key]) buckets[key] = { wins: 0, losses: 0, draws: 0, score: 0, games: 0, duration: 0, ratings: [] };
+    if (!buckets[key]) buckets[key] = { date: dateKey, format: format, wins: 0, losses: 0, draws: 0, score: 0, games: 0, duration: 0, ratings: [] };
     var b = buckets[key];
     var outcome = row[18];
     var score = row[19];
@@ -148,7 +148,7 @@ function buildDailyRowsWithMain3(buckets) {
       re = Math.max.apply(null, b.ratings);
       rc = Number(re) - Number(rs);
     }
-    rows.push([b.date, b.format, b.wins, b.losses, b.draws, b.score, rs, re, rc, b.games, b.duration, '', '']);
+    rows.push([b.date, b.format, b.wins, b.losses, b.draws, b.score, rs, re, rc, b.games, b.duration]);
     (byDate[b.date] = byDate[b.date] || {})[b.format] = { wins: b.wins, losses: b.losses, draws: b.draws, score: b.score, games: b.games, duration: b.duration, rs: rs, re: re };
   }
   // Add Main3 aggregates
@@ -168,17 +168,21 @@ function buildDailyRowsWithMain3(buckets) {
       var rs = starts.length ? Math.min.apply(null, starts) : '';
       var re = ends.length ? Math.max.apply(null, ends) : '';
       var rc = (rs === '' || re === '') ? '' : (Number(re) - Number(rs));
-      rows.push([date, 'Main3', wins, losses, draws, score, rs, re, rc, games, duration, '', '']);
+      rows.push([date, 'Main3', wins, losses, draws, score, rs, re, rc, games, duration]);
     }
   });
   // Sort by date asc; format order: bullet, blitz, rapid, Main3, others alpha
   var order = { bullet:1, blitz:2, rapid:3, Main3:4 };
   rows.sort(function(a,b){
     if (a[0] !== b[0]) return a[0] < b[0] ? -1 : 1;
-    var fa = a[1], fb = b[1];
-    var oa = order[fa] || 1000 + fa.charCodeAt(0);
-    var ob = order[fb] || 1000 + fb.charCodeAt(0);
-    return oa - ob;
+    var fa = a[1] || '';
+    var fb = b[1] || '';
+    var oa = (order[fa] !== undefined) ? order[fa] : 1000;
+    var ob = (order[fb] !== undefined) ? order[fb] : 1000;
+    if (oa !== ob) return oa - ob;
+    if (fa < fb) return -1;
+    if (fa > fb) return 1;
+    return 0;
   });
   return rows;
 }


### PR DESCRIPTION
Fix `TypeError: Cannot read properties of undefined (reading 'charCodeAt')` and remove unneeded exactness columns from daily sheets.

The `charCodeAt` error occurred because the `format` field in the daily row buckets was not always initialized, leading to `undefined` values being passed to the sort comparator. This PR ensures `date` and `format` are always present in the buckets and hardens the sort logic to handle potentially missing format values gracefully.

---
<a href="https://cursor.com/background-agent?bcId=bc-aef4d8d6-6d0b-4db9-807c-4877773493de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aef4d8d6-6d0b-4db9-807c-4877773493de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

