### PR TITLE
Fetch and log chess.com stats

### DIFF
--- a/apps_script/config.gs
+++ b/apps_script/config.gs
@@ -29,6 +29,8 @@ const CONFIG = {
     DailyArchive: 'DailyTotals_Archive',
     DailyTotals: 'DailyTotals',
     CallbackStats: 'CallbackStats',
+    LiveStatsEOD: 'LiveStatsEOD',
+    LiveStatsMeta: 'LiveStatsMeta',
     Logs: 'Logs'
   },
   HEADERS: {
@@ -63,6 +65,20 @@ const CONFIG = {
       'black_username', 'black_rating', 'black_country', 'black_membership', 'black_default_tab', 'black_post_move_action',
       'eco_code', 'pgn_date', 'pgn_time', 'base_time1', 'time_increment1',
       'data_json', 'fetched_at'
+    ],
+    LiveStatsEOD: [
+      'date', 'format', 'eod_rating', 'rating_raw', 'day_close_rating_raw', 'timestamp_ms', 'day_index'
+    ],
+    LiveStatsMeta: [
+      'fetched_at', 'format',
+      'count', 'rated_count',
+      'opponent_rating_avg', 'opponent_rating_win_avg', 'opponent_rating_draw_avg', 'opponent_rating_loss_avg',
+      'white_game_count', 'black_game_count', 'white_win_count', 'white_draw_count', 'white_loss_count', 'black_win_count', 'black_draw_count', 'black_loss_count',
+      'rating_last', 'rating_first', 'rating_max', 'rating_max_timestamp',
+      'moves_count', 'streak_last', 'streak_max', 'streak_max_timestamp',
+      'opponent_rating_max', 'opponent_rating_max_timestamp', 'opponent_rating_max_uuid',
+      'accuracy_count', 'accuracy_avg', 'starting_day',
+      'progress', 'rank', 'percentile', 'playersCount', 'friendRank', 'friendRankIsExpired'
     ],
     Logs: ['timestamp', 'level', 'code', 'message', 'context_json']
   }

--- a/apps_script/main.gs
+++ b/apps_script/main.gs
@@ -9,6 +9,8 @@ function setupProject() {
   // Consolidated DailyTotals sheet is authoritative
   getOrCreateSheet(metricsSS, CONFIG.SHEET_NAMES.DailyTotals, CONFIG.HEADERS.DailyTotals);
   getOrCreateSheet(metricsSS, CONFIG.SHEET_NAMES.CallbackStats, CONFIG.HEADERS.CallbackStats);
+  getOrCreateSheet(metricsSS, CONFIG.SHEET_NAMES.LiveStatsEOD, CONFIG.HEADERS.LiveStatsEOD);
+  getOrCreateSheet(metricsSS, CONFIG.SHEET_NAMES.LiveStatsMeta, CONFIG.HEADERS.LiveStatsMeta);
   getOrCreateSheet(metricsSS, CONFIG.SHEET_NAMES.Logs, CONFIG.HEADERS.Logs);
 
   // Discover archives and write

--- a/apps_script/stats_live.gs
+++ b/apps_script/stats_live.gs
@@ -1,0 +1,107 @@
+function updateLiveStatsAll() {
+  updateLiveStatsForFormat('bullet');
+  updateLiveStatsForFormat('blitz');
+  updateLiveStatsForFormat('rapid');
+}
+
+function updateLiveStatsForFormat(format) {
+  if (!format) return;
+  var username = getConfiguredUsername();
+  var url = buildLiveStatsUrl(format, username);
+  try {
+    // Always fetch to capture a fresh meta snapshot each run
+    var resp = UrlFetchApp.fetch(url, {
+      muteHttpExceptions: true,
+      followRedirects: true,
+      headers: { 'User-Agent': 'ChessSheets/1.0 (AppsScript)', 'Accept': 'application/json' }
+    });
+    var code = resp.getResponseCode();
+    if (code < 200 || code >= 300) {
+      logWarn('LIVESTATS_HTTP', 'Non-2xx fetching live stats', { format: format, code: code, url: url });
+      return;
+    }
+    var json = JSON.parse(resp.getContentText() || '{}');
+    if (!json || !json.stats) {
+      logWarn('LIVESTATS_EMPTY', 'No stats payload', { format: format });
+      return;
+    }
+    appendLiveStatsMeta(format, json);
+    appendLiveStatsHistory(format, json);
+  } catch (e) {
+    logError('LIVESTATS_ERR', String(e && e.message || e), { format: format, url: url });
+  }
+}
+
+function buildLiveStatsUrl(format, username) {
+  return 'https://www.chess.com/callback/stats/live/' + encodeURIComponent(format) + '/' + encodeURIComponent(username) + '/0';
+}
+
+function appendLiveStatsMeta(format, payload) {
+  try {
+    var metricsSS = getOrCreateMetricsSpreadsheet();
+    var sheet = getOrCreateSheet(metricsSS, CONFIG.SHEET_NAMES.LiveStatsMeta, CONFIG.HEADERS.LiveStatsMeta);
+    var s = payload.stats || {};
+    var row = [
+      new Date(),
+      String(format || ''),
+      safe(s.count), safe(s.rated_count),
+      safe(s.opponent_rating_avg), safe(s.opponent_rating_win_avg), safe(s.opponent_rating_draw_avg), safe(s.opponent_rating_loss_avg),
+      safe(s.white_game_count), safe(s.black_game_count), safe(s.white_win_count), safe(s.white_draw_count), safe(s.white_loss_count), safe(s.black_win_count), safe(s.black_draw_count), safe(s.black_loss_count),
+      safe(s.rating_last), safe(s.rating_first), safe(s.rating_max), safe(s.rating_max_timestamp),
+      safe(s.moves_count), safe(s.streak_last), safe(s.streak_max), safe(s.streak_max_timestamp),
+      safe(s.opponent_rating_max), safe(s.opponent_rating_max_timestamp), safe(s.opponent_rating_max_uuid),
+      safe(s.accuracy_count), safe(s.accuracy_avg), safe(s.starting_day),
+      safe(payload.progress), safe(payload.rank), safe(payload.percentile), safe(payload.playersCount), safe(payload.friendRank), safe(payload.friendRankIsExpired)
+    ];
+    writeRowsChunked(sheet, [row]);
+  } catch (e) {
+    logWarn('LIVESTATS_META_FAIL', 'Failed writing LiveStatsMeta', { format: format, error: String(e) });
+  }
+}
+
+function appendLiveStatsHistory(format, payload) {
+  var stats = payload && payload.stats;
+  var hist = stats && stats.history;
+  if (!hist || !hist.length) return;
+
+  var props = getScriptProps();
+  var cursorKey = 'CURSOR_LIVESTATS_' + String(format).toUpperCase() + '_MAX_TS';
+  var lastTsStr = props.getProperty(cursorKey);
+  var lastTs = lastTsStr ? parseInt(lastTsStr, 10) : 0;
+
+  // Filter new entries strictly greater than cursor timestamp
+  var newEntries = [];
+  for (var i = 0; i < hist.length; i++) {
+    var h = hist[i] || {};
+    var ts = Number(h.timestamp || 0); // appears to be ms epoch in callback response
+    if (!ts) continue;
+    if (lastTs && ts <= lastTs) continue;
+    newEntries.push(h);
+  }
+  if (!newEntries.length) return;
+
+  // Sort ascending by timestamp so we append in chronological order
+  newEntries.sort(function(a, b){ return Number(a.timestamp || 0) - Number(b.timestamp || 0); });
+
+  var metricsSS = getOrCreateMetricsSpreadsheet();
+  var sheet = getOrCreateSheet(metricsSS, CONFIG.SHEET_NAMES.LiveStatsEOD, CONFIG.HEADERS.LiveStatsEOD);
+  var tz = getProjectTimeZone();
+  var rows = [];
+  var maxTs = lastTs;
+  for (var j = 0; j < newEntries.length; j++) {
+    var e = newEntries[j];
+    var tsMs = Number(e.timestamp || 0);
+    if (tsMs > maxTs) maxTs = tsMs;
+    var dateStr = Utilities.formatDate(new Date(tsMs), tz, 'yyyy-MM-dd');
+    var ratingRaw = e.rating;
+    var dayCloseRaw = e.day_close_rating;
+    var eod = (dayCloseRaw !== undefined && dayCloseRaw !== null && Number(dayCloseRaw) !== 0)
+      ? Number(dayCloseRaw)
+      : (ratingRaw !== undefined && ratingRaw !== null ? Number(ratingRaw) : '');
+    var dayIndex = (e.day !== undefined && e.day !== null) ? Number(e.day) : '';
+    rows.push([dateStr, String(format || ''), eod, safe(ratingRaw), safe(dayCloseRaw), tsMs, dayIndex]);
+  }
+  if (rows.length) writeRowsChunked(sheet, rows);
+  if (maxTs && maxTs > lastTs) props.setProperty(cursorKey, String(maxTs));
+}
+

--- a/apps_script/triggers.gs
+++ b/apps_script/triggers.gs
@@ -9,6 +9,11 @@ function installTriggers() {
     .timeBased()
     .everyMinutes(15)
     .create();
+  // Update live stats (bullet/blitz/rapid) every 2 hours
+  ScriptApp.newTrigger('updateLiveStatsAll')
+    .timeBased()
+    .everyHours(2)
+    .create();
   // Month rollover check at 01:10 daily (cheap, fast)
   ScriptApp.newTrigger('ensureMonthRollover')
     .timeBased()


### PR DESCRIPTION
Add Chess.com live stats sheets and updater to track historical ratings and metadata, enabling long-term performance analysis with incremental updates.

The `LiveStatsEOD` sheet is updated incrementally using a per-format timestamp cursor to only append new history entries, preserving historical data without duplication.

---
<a href="https://cursor.com/background-agent?bcId=bc-c85edf5a-e0d9-4551-b91e-ad29a1ed03dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c85edf5a-e0d9-4551-b91e-ad29a1ed03dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

