### PR TITLE
Fix io tab reference error

### DIFF
--- a/apps_script/logging.gs
+++ b/apps_script/logging.gs
@@ -1,7 +1,7 @@
 function logEvent(level, code, message, context) {
   try {
-    var metricsSS = getOrCreateMetricsSpreadsheet();
-    var sheet = getOrCreateSheet(metricsSS, CONFIG.SHEET_NAMES.Logs, CONFIG.HEADERS.Logs);
+    var logsSS = getOrCreateLogsSpreadsheet();
+    var sheet = getOrCreateSheet(logsSS, CONFIG.SHEET_NAMES.Logs, CONFIG.HEADERS.Logs);
     var row = [new Date(), String(level || 'INFO'), String(code || ''), String(message || ''), context ? JSON.stringify(context) : ''];
     writeRowsChunked(sheet, [row]);
   } catch (e) {


### PR DESCRIPTION
Resolve `ReferenceError` by using `getOrCreateLogsSpreadsheet` in `logging.gs` instead of the undefined `getOrCreateMetricsSpreadsheet`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c2cb98d-ca04-4dd5-920a-47da9dea0489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c2cb98d-ca04-4dd5-920a-47da9dea0489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

