### PR TITLE
Ensure sheets and headers exist

### DIFF
--- a/apps_script/io.gs
+++ b/apps_script/io.gs
@@ -165,10 +165,6 @@ function ensureFileInProjectFolder(fileId) {
 }
 
 // Legacy compatibility for older "Metrics" API
-function getSpreadsheetNameMetrics() {
-  return getSpreadsheetNameLogs();
-}
-
-function getOrCreateMetricsSpreadsheet() {
-  return getOrCreateLogsSpreadsheet();
-}
+// Deprecated: legacy "Metrics" alias kept for backward compatibility
+function getSpreadsheetNameMetrics() { return getSpreadsheetNameLogs(); }
+function getOrCreateMetricsSpreadsheet() { return getOrCreateLogsSpreadsheet(); }

--- a/chess mds/DataModel.md
+++ b/chess mds/DataModel.md
@@ -1,6 +1,15 @@
 ### Data Model
 
-All data lives in two spreadsheets: Games (raw normalized games) and Metrics (meta/aggregates/logs). Column orders are stable and versioned via schema_version in Archives.
+All data lives across multiple spreadsheets for clarity and performance:
+- Games (raw normalized games)
+- Archives (per-month operational metadata)
+- DailyTotals (aggregated per date+format)
+- Callbacks (CallbackStats raw JSON and derived fields)
+- Ratings (Ratings timeline and Adjustments)
+- Stats (PlayerStats snapshots)
+- LiveStats (LiveStatsEOD and LiveStatsMeta)
+- Logs (structured events)
+Column orders are stable and versioned via schema_version in Archives.
 
 ### Sheet: Games (canonical per-game rows)
 Columns (order is canonical):

--- a/chess mds/Overview.md
+++ b/chess mds/Overview.md
@@ -4,7 +4,13 @@ This project ingests your complete Chess.com game history into Google Sheets, ke
 
 ### Components
 - Games spreadsheet: canonical table of all games (one row per game).
-- Metrics spreadsheet: operational/meta sheets — Archives, DailyTotals, CallbackStats, Logs.
+- Callbacks spreadsheet: `CallbackStats` (raw per-game callback JSON and derived fields).
+- Ratings spreadsheet: `Ratings` and `Adjustments` (timeline and manual adjustments).
+- Stats spreadsheet: `PlayerStats` (point-in-time player rating snapshots).
+- LiveStats spreadsheet: `LiveStatsEOD`, `LiveStatsMeta` (daily close and meta aggregates).
+- Archives spreadsheet: `Archives` (per-month operational metadata and counters).
+- DailyTotals spreadsheet: `DailyTotals` (aggregated per date+format performance).
+- Logs spreadsheet: `Logs` (structured events and diagnostics).
 
 ### Core Capabilities
 - Initial discovery of all monthly archive URLs for a user.

--- a/chess mds/SetupReset.md
+++ b/chess mds/SetupReset.md
@@ -5,10 +5,22 @@ Initial Setup (fresh project)
    - CHESS_USERNAME (required)
    - TIMEZONE (optional)
    - SPREADSHEET_NAME_GAMES (optional)
-   - SPREADSHEET_NAME_METRICS (optional)
+   - SPREADSHEET_NAME_CALLBACKS (optional)
+   - SPREADSHEET_NAME_RATINGS (optional)
+   - SPREADSHEET_NAME_STATS (optional)
+   - SPREADSHEET_NAME_LIVESTATS (optional)
+   - SPREADSHEET_NAME_ARCHIVES (optional)
+   - SPREADSHEET_NAME_DAILYTOTALS (optional)
+   - SPREADSHEET_NAME_LOGS (optional)
 2. Create/open spreadsheets:
    - Games: creates sheet `Games` with canonical headers.
-   - Metrics: creates `Archives`, `DailyTotals`, `CallbackStats`, `Logs` with headers.
+   - Callbacks: creates `CallbackStats`.
+   - Ratings: creates `Ratings` and `Adjustments`.
+   - Stats: creates `PlayerStats`.
+   - LiveStats: creates `LiveStatsEOD` and `LiveStatsMeta`.
+   - Archives: creates `Archives`.
+   - DailyTotals: creates `DailyTotals`.
+   - Logs: creates `Logs`.
 3. Discover and write `Archives` rows for all months.
 
 Full Backfill

--- a/chess mds/StateProperties.md
+++ b/chess mds/StateProperties.md
@@ -5,10 +5,22 @@ Persistent Keys (Script Properties)
 CHESS_USERNAME: required username for ingestion
 TIMEZONE: optional, overrides project timezone (e.g., America/New_York)
 SPREADSHEET_NAME_GAMES: optional display name
-SPREADSHEET_NAME_METRICS: optional display name
+SPREADSHEET_NAME_CALLBACKS: optional display name
+SPREADSHEET_NAME_RATINGS: optional display name
+SPREADSHEET_NAME_STATS: optional display name
+SPREADSHEET_NAME_LIVESTATS: optional display name
+SPREADSHEET_NAME_ARCHIVES: optional display name
+SPREADSHEET_NAME_DAILYTOTALS: optional display name
+SPREADSHEET_NAME_LOGS: optional display name
 
 SPREADSHEET_ID_GAMES: created and stored on first creation/open
-SPREADSHEET_ID_METRICS: created and stored on first creation/open
+SPREADSHEET_ID_CALLBACKS: created and stored on first creation/open
+SPREADSHEET_ID_RATINGS: created and stored on first creation/open
+SPREADSHEET_ID_STATS: created and stored on first creation/open
+SPREADSHEET_ID_LIVESTATS: created and stored on first creation/open
+SPREADSHEET_ID_ARCHIVES: created and stored on first creation/open
+SPREADSHEET_ID_DAILYTOTALS: created and stored on first creation/open
+SPREADSHEET_ID_LOGS: created and stored on first creation/open
 
 CURSOR_YYYY_MM_END_EPOCH: per-month last ingested end_time (unix seconds)
 PROJECT_FOLDER_NAME: optional, not required in the current simplified flow


### PR DESCRIPTION
Update documentation and deprecate legacy helpers to reflect the multi-spreadsheet architecture instead of a single "Metrics" spreadsheet.

The project's setup creates multiple distinct spreadsheets (e.g., Archives, DailyTotals, Logs) but some documentation and helper functions still referred to a single, consolidated "Metrics" spreadsheet. This PR resolves that inconsistency by updating all relevant descriptions and deprecating the `metricsSS` aliases, ensuring clarity and alignment with the actual data model.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b11bbd4-5968-4710-9281-2dfa11b45beb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b11bbd4-5968-4710-9281-2dfa11b45beb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

