### PR TITLE
Understand project structure

### DIFF
--- a/apps_script/config.gs
+++ b/apps_script/config.gs
@@ -58,7 +58,7 @@ const CONFIG = {
       'start_time', 'end_time', 'duration_seconds',
       'rated', 'time_class', 'rules', 'format',
       'player_username', 'player_color', 'player_rating', 'player_result', 'player_outcome', 'player_score',
-      'opponent_username', 'opponent_color', 'opponent_rating',
+      'opponent_username', 'opponent_color', 'opponent_rating', 'opponent_result', 'opponent_outcome', 'opponent_score',
       'eco_code', 'eco_url', 'uuid', 'end_reason', 'pgn_moves'
     ],
     DailyTotals: [

--- a/apps_script/transform.gs
+++ b/apps_script/transform.gs
@@ -22,6 +22,8 @@ function gameJsonToRow(meUsername, game) {
   var playerOutcome = mapResultToOutcome(playerResult);
   var playerScore = scoreFromOutcome(playerOutcome);
   var opponentResult = opponent && opponent.result ? String(opponent.result) : '';
+  var opponentOutcome = mapResultToOutcome(opponentResult);
+  var opponentScore = scoreFromOutcome(opponentOutcome);
   var ecoCode = (game.pgn && extractPgnHeader(game.pgn, 'ECO')) || game.eco || '';
   var ecoUrl = (game.pgn && extractPgnHeader(game.pgn, 'ECOUrl')) || game.eco_url || '';
   var uuid = game.uuid || '';
@@ -34,7 +36,7 @@ function gameJsonToRow(meUsername, game) {
     safe(startLocal), safe(endLocal), safe(durationSeconds),
     safe(game.rated), safe(timeClass), safe(rules), safe(format),
     safe(player.username), safe(meColor), safe(player.rating), safe(playerResult), safe(playerOutcome), safe(playerScore),
-    safe(opponent.username), safe(oppColor), safe(opponent.rating),
+    safe(opponent.username), safe(oppColor), safe(opponent.rating), safe(opponentResult), safe(opponentOutcome), safe(opponentScore),
     safe(ecoCode), safe(ecoUrl), safe(uuid), safe(endReason), safe(pgnMoves)
   ];
 }
@@ -109,17 +111,20 @@ function normalizeEndReason(playerOutcome, opponentResult, pgn) {
     if (tl.indexOf('50-move') >= 0 || tl.indexOf('50 move') >= 0) return '50move';
     if (tl.indexOf('draw') >= 0) return 'agreed';
   }
-  var r = String(opponentResult || '').toLowerCase();
-  if (!r) return '';
-  if (r === 'checkmated') return 'checkmate';
-  if (r === 'timeout') return 'timeout';
-  if (r === 'resigned') return 'resign';
-  if (r === 'abandoned') return 'abandoned';
-  if (r === 'stalemate') return 'stalemate';
-  if (r === 'repetition') return 'repetition';
-  if (r === 'insufficient') return 'insufficient';
-  if (r === '50move') return '50move';
-  if (r === 'timevsinsufficient') return 'timevsinsufficient';
+  // If not available from PGN, infer from loser result when decisive, else draw
+  var opp = String(opponentResult || '').toLowerCase();
+  if (playerOutcome === 'win') {
+    // Opponent lost: map opponent's result to reason
+    if (opp === 'checkmated') return 'checkmate';
+    if (opp === 'timeout') return 'timeout';
+    if (opp === 'resigned') return 'resign';
+    if (opp === 'abandoned') return 'abandoned';
+    if (opp === 'stalemate') return 'stalemate';
+    if (opp === 'repetition') return 'repetition';
+    if (opp === 'insufficient') return 'insufficient';
+    if (opp === '50move') return '50move';
+    if (opp === 'timevsinsufficient') return 'timevsinsufficient';
+  }
   if (playerOutcome === 'draw') return 'agreed';
   return '';
 }


### PR DESCRIPTION
Add opponent result, outcome, and score fields, and refine `end_reason` calculation to improve game data completeness and accuracy.

The `end_reason` logic now prioritizes the PGN `Termination` header, then infers the reason from the losing player's result (e.g., 'checkmate', 'timeout'), and defaults to 'agreed' for draws, addressing previous issues with blank or incorrectly derived values.

---
<a href="https://cursor.com/background-agent?bcId=bc-597f52fa-1eb1-4bb0-9e29-7cc8f4ee1814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-597f52fa-1eb1-4bb0-9e29-7cc8f4ee1814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

